### PR TITLE
Fix build issues on macOS 10.14

### DIFF
--- a/Source/AppDelegate.m
+++ b/Source/AppDelegate.m
@@ -5,7 +5,7 @@
 #import "KeychainSupport.h"
 #import "pinentry.h"
 #ifdef FALLBACK_CURSES
-#include <pinentry-curses.h>
+#include "pinentry-curses.h"
 #endif
 
 

--- a/Source/main.m
+++ b/Source/main.m
@@ -47,7 +47,7 @@ BOOL isBundleValidSigned(NSBundle *bundle) {
 
 
 #ifdef FALLBACK_CURSES
-#import <pinentry-curses.h>
+#import "pinentry-curses.h"
 
 /* On Mac, the DISPLAY environment variable, which is passed from
  a session to gpg2 to gpg-agent to pinentry and which is used

--- a/Source/pinentry-0.9.4/assuan/assuan-buffer.c
+++ b/Source/pinentry-0.9.4/assuan/assuan-buffer.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/Source/pinentry-0.9.4/assuan/assuan-handler.c
+++ b/Source/pinentry-0.9.4/assuan/assuan-handler.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/Source/pinentry-0.9.4/assuan/assuan-listen.c
+++ b/Source/pinentry-0.9.4/assuan/assuan-listen.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/Source/pinentry-0.9.4/assuan/assuan-pipe-server.c
+++ b/Source/pinentry-0.9.4/assuan/assuan-pipe-server.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/Source/pinentry-0.9.4/assuan/assuan-util.c
+++ b/Source/pinentry-0.9.4/assuan/assuan-util.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/Source/pinentry-0.9.4/pinentry/argparse.c
+++ b/Source/pinentry-0.9.4/pinentry/argparse.c
@@ -35,7 +35,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <stdio.h>

--- a/Source/pinentry-0.9.4/pinentry/password-cache.c
+++ b/Source/pinentry-0.9.4/pinentry/password-cache.c
@@ -18,7 +18,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-# include <config.h>
+# include "config.h"
 #endif
 
 #include <stdlib.h>

--- a/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
+++ b/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
@@ -19,7 +19,7 @@
    02111-1307, USA  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 #include <assert.h>
 #ifdef HAVE_NCURSESW

--- a/Source/pinentry-0.9.4/pinentry/pinentry.c
+++ b/Source/pinentry-0.9.4/pinentry/pinentry.c
@@ -18,7 +18,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #ifndef HAVE_W32CE_SYSTEM

--- a/Source/pinentry-0.9.4/secmem/secmem.c
+++ b/Source/pinentry-0.9.4/secmem/secmem.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #ifndef HAVE_W32CE_SYSTEM

--- a/Source/pinentry-0.9.4/secmem/util.c
+++ b/Source/pinentry-0.9.4/secmem/util.c
@@ -17,7 +17,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #define _GNU_SOURCE 1


### PR DESCRIPTION
This fixes a build issue on macOS 10.14 (Mojave) where clang complained
that the header files `<config.h>` and `<pinentry-curses.h>` could not
be found.